### PR TITLE
Configure PDF.js worker for Cloudflare Pages

### DIFF
--- a/lib/parsers.ts
+++ b/lib/parsers.ts
@@ -2,6 +2,9 @@
 
 import * as pdfjsLib from 'pdfjs-dist';
 
+// Configure PDF.js worker for Cloudflare Pages
+pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.worker.min.js`;
+
 /**
  * Extract text from PDF file using pdfjs-dist (Edge runtime compatible)
  */


### PR DESCRIPTION
- Add GlobalWorkerOptions.workerSrc with CDN URL
- Fixes 'No GlobalWorkerOptions.workerSrc specified' error
- Use jsdelivr CDN for pdfjs-dist worker