### PR TITLE
Implement client-side PDF parsing for Edge runtime

### DIFF
--- a/app/api/upload/route.ts
+++ b/app/api/upload/route.ts
@@ -23,6 +23,7 @@ export async function POST(request: NextRequest) {
     // Parse multipart form data
     const formData = await request.formData();
     const file = formData.get('file') as File;
+    const extractedText = formData.get('extractedText') as string | null;
 
     if (!file) {
       return NextResponse.json(
@@ -53,8 +54,16 @@ export async function POST(request: NextRequest) {
     const buffer = Buffer.from(arrayBuffer);
 
     // Extract text from file
-    console.log(`Extracting text from ${fileType} file: ${file.name}`);
-    const text = await extractText(buffer, fileType);
+    let text: string;
+    if (extractedText) {
+      // Use pre-extracted text from client (for PDF files)
+      console.log(`Using pre-extracted text from client for ${fileType} file: ${file.name}`);
+      text = extractedText;
+    } else {
+      // Extract text on server (for Markdown files)
+      console.log(`Extracting text from ${fileType} file: ${file.name}`);
+      text = await extractText(buffer, fileType);
+    }
 
     if (!text || text.trim().length === 0) {
       return NextResponse.json(

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useCallback, useEffect } from "react";
 import { useDropzone } from "react-dropzone";
+import { extractTextFromPDFClient } from "@/lib/pdf-client";
 import type { ChatResponse, StatsResponse, UploadResponse, DeleteResponse } from "@/env";
 
 type Tab = "chat" | "upload" | "documents";
@@ -209,6 +210,16 @@ function UploadTab() {
     try {
       const formData = new FormData();
       formData.append("file", file);
+
+      // For PDF files, extract text on the client side
+      if (file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf")) {
+        try {
+          const extractedText = await extractTextFromPDFClient(file);
+          formData.append("extractedText", extractedText);
+        } catch (pdfError) {
+          throw new Error(`PDF parsing failed: ${pdfError instanceof Error ? pdfError.message : 'Unknown error'}`);
+        }
+      }
 
       const res = await fetch("/api/upload", {
         method: "POST",

--- a/lib/pdf-client.ts
+++ b/lib/pdf-client.ts
@@ -1,0 +1,41 @@
+// Client-side PDF text extraction using PDF.js
+// This runs in the browser, not on the Edge runtime
+
+import * as pdfjsLib from 'pdfjs-dist';
+
+// Configure PDF.js worker for browser
+if (typeof window !== 'undefined') {
+  pdfjsLib.GlobalWorkerOptions.workerSrc = `https://cdn.jsdelivr.net/npm/pdfjs-dist@3.11.174/build/pdf.worker.min.js`;
+}
+
+/**
+ * Extract text from PDF file in the browser
+ * @param file - PDF File object from file input
+ * @returns Extracted text content
+ */
+export async function extractTextFromPDFClient(file: File): Promise<string> {
+  try {
+    // Convert file to ArrayBuffer
+    const arrayBuffer = await file.arrayBuffer();
+
+    // Load PDF document
+    const loadingTask = pdfjsLib.getDocument({ data: arrayBuffer });
+    const pdf = await loadingTask.promise;
+
+    const textParts: string[] = [];
+
+    // Extract text from each page
+    for (let pageNum = 1; pageNum <= pdf.numPages; pageNum++) {
+      const page = await pdf.getPage(pageNum);
+      const textContent = await page.getTextContent();
+      const pageText = textContent.items
+        .map((item: any) => item.str)
+        .join(' ');
+      textParts.push(pageText);
+    }
+
+    return textParts.join('\n\n');
+  } catch (error) {
+    throw new Error(`Failed to parse PDF: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}


### PR DESCRIPTION
- Create lib/pdf-client.ts for browser-based PDF text extraction
- Modify UploadTab to extract PDF text on client before upload
- Update upload API to accept pre-extracted text from client
- PDF parsing now works in Cloudflare Pages Edge runtime
- Markdown files continue to work as before (server-side parsing)